### PR TITLE
Enable Cync 2FA Authentication

### DIFF
--- a/custom_components/gelight/light.py
+++ b/custom_components/gelight/light.py
@@ -247,6 +247,8 @@ class GEDevice(LightEntity):
     def support_color_temp(self):
         if self.support_rgb() or \
            self.type == 5 or \
+           self.type == 10 or \
+           self.type == 11 or \
            self.type == 19 or \
            self.type == 20 or \
            self.type == 80 or \


### PR DESCRIPTION
This worked for me, adds Cync's (Savant/GE's) 2FA process that was required/enabled when they transitioned to Cync. 

Addresses Issue https://github.com/yangqian/hass-gelight/issues/7 