### PR TITLE
Add additional temp supported bulbs

### DIFF
--- a/custom_components/gelight/light.py
+++ b/custom_components/gelight/light.py
@@ -247,6 +247,8 @@ class GEDevice(LightEntity):
     def support_color_temp(self):
         if self.support_rgb() or \
            self.type == 5 or \
+           self.type == 10 or \
+           self.type == 11 or \
            self.type == 19 or \
            self.type == 20 or \
            self.type == 80 or \


### PR DESCRIPTION
Bulb types 10 (A19) and 11 (BR30) both support CCT/temperature attenuation