### PR TITLE
Update manifest.json

### DIFF
--- a/custom_components/gelight/manifest.json
+++ b/custom_components/gelight/manifest.json
@@ -1,6 +1,7 @@
 {
   "domain": "gelight",
   "name": "GE Light Local Bluetooth Controller",
+  "version": "0.1",
   "documentation": "https://github.com/yangqian/hass-gelight",
   "dependencies": [],
   "codeowners": ["@yangqian"],


### PR DESCRIPTION
Home Assistant now requires version key. See https://developers.home-assistant.io/blog/2021/01/29/custom-integration-changes/#versions